### PR TITLE
Add RNFirbase for Firebase intregation

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -42,6 +42,7 @@ matrix:
         components:
           - build-tools-23.0.1
           - android-23
+          - android-25
           - extra-android-m2repository
           - extra-google-google_play_services
           - extra-google-m2repository

--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -130,7 +130,18 @@ dependencies {
     compile fileTree(dir: "libs", include: ["*.jar"])
     compile "com.android.support:appcompat-v7:23.0.1"
     compile "com.facebook.react:react-native:+"  // From node_modules
+
+    // RNFirebase required dependencies
+    compile(project(':react-native-firebase')) {
+      transitive = false
+    }
+    compile "com.google.firebase:firebase-core:11.0.0"
+
+    // If you are receiving Google Play API availability issues, add the following dependency
+    // compile "com.google.android.gms:play-services-base:11.0.0"
 }
+
+apply plugin: 'com.google.gms.google-services'
 
 // Run this once to be able to run the application with BUCK
 // puts all compile dependencies into folder libs for BUCK to use

--- a/android/app/google-services.json
+++ b/android/app/google-services.json
@@ -1,0 +1,55 @@
+{
+  "project_info": {
+    "project_number": "502584752547",
+    "firebase_url": "https://project-7593821828655173684.firebaseio.com",
+    "project_id": "project-7593821828655173684",
+    "storage_bucket": "project-7593821828655173684.appspot.com"
+  },
+  "client": [
+    {
+      "client_info": {
+        "mobilesdk_app_id": "1:502584752547:android:e3d7a6ebd70b1482",
+        "android_client_info": {
+          "package_name": "org.gdgsrilanka.codelanka.eznet"
+        }
+      },
+      "oauth_client": [
+        {
+          "client_id": "502584752547-ofmc6qbtfmbvsthbn5pj8ih3kg3ddsrd.apps.googleusercontent.com",
+          "client_type": 1,
+          "android_info": {
+            "package_name": "org.gdgsrilanka.codelanka.eznet",
+            "certificate_hash": "031b3fda8372c21778b1bf9e5f12974d7dc95fd0"
+          }
+        },
+        {
+          "client_id": "502584752547-oq47kki31psm060pn8r7fbs87a2n7jef.apps.googleusercontent.com",
+          "client_type": 3
+        }
+      ],
+      "api_key": [
+        {
+          "current_key": "AIzaSyDXV-ym30hM8mMLzhBOc6JudoOjdqhUPJ4"
+        }
+      ],
+      "services": {
+        "analytics_service": {
+          "status": 1
+        },
+        "appinvite_service": {
+          "status": 2,
+          "other_platform_oauth_client": [
+            {
+              "client_id": "502584752547-oq47kki31psm060pn8r7fbs87a2n7jef.apps.googleusercontent.com",
+              "client_type": 3
+            }
+          ]
+        },
+        "ads_service": {
+          "status": 2
+        }
+      }
+    }
+  ],
+  "configuration_version": "1"
+}

--- a/android/app/src/main/java/com/reactnativeproject/MainApplication.java
+++ b/android/app/src/main/java/com/reactnativeproject/MainApplication.java
@@ -11,6 +11,8 @@ import com.facebook.react.ReactPackage;
 import com.facebook.react.shell.MainReactPackage;
 import com.facebook.soloader.SoLoader;
 
+import io.invertase.firebase.RNFirebasePackage;
+
 import java.util.Arrays;
 import java.util.List;
 
@@ -26,6 +28,7 @@ public class MainApplication extends Application implements ReactApplication {
     protected List<ReactPackage> getPackages() {
       return Arrays.<ReactPackage>asList(
           new MainReactPackage(),
+          new RNFirebasePackage(),
             new VectorIconsPackage()
       );
     }

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -6,6 +6,7 @@ buildscript {
     }
     dependencies {
         classpath 'com.android.tools.build:gradle:2.2.3'
+        classpath 'com.google.gms:google-services:3.0.0'
 
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files

--- a/android/settings.gradle
+++ b/android/settings.gradle
@@ -1,5 +1,7 @@
 rootProject.name = 'ReactNativeProject'
 include ':react-native-vector-icons'
 project(':react-native-vector-icons').projectDir = new File(rootProject.projectDir, '../node_modules/react-native-vector-icons/android')
+include ':react-native-firebase'
+project(':react-native-firebase').projectDir = new File(rootProject.projectDir, '../node_modules/react-native-firebase/android')
 
 include ':app'

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "react-burger-menu": "^2.1.3",
     "react-burger-nav": "^2.0.2",
     "react-native": "0.45.1",
+    "react-native-firebase": "^2.0.2",
     "react-native-material-ui": "^1.12.0",
     "react-native-responsive-image": "^2.1.0",
     "react-navigation": "^1.0.0-beta.11"


### PR DESCRIPTION
Fix #4 
Added just the base foundation parts, the community can work on the rest. 

Refer http://invertase.io/react-native-firebase/#/

Following  packages can be added as e need, 

1. AdMob Package
2. Analytics Package
3. Auth Package
4. RemoteConfig Package
5. Crash Package
6. Database Package
7. Messaging Package
8. Performance Package
9. Storage Package

Refer http://invertase.io/react-native-firebase/#/installation-android